### PR TITLE
Ignore DMs so bot can't be crashed

### DIFF
--- a/events/message.js
+++ b/events/message.js
@@ -1,6 +1,9 @@
 const config = require('../config.json');
 
 module.exports = (client, message) => {
+    // Ignore direct messages
+	if(message.channel.type === 'dm') return;
+    
     // Ignore all bots
     if (message.author.bot) return;
   


### PR DESCRIPTION
If the bot doesn't ignore DMs, any user can send one of the commands to it in DM and the bot will crash. The code committed in this PR resolves that.